### PR TITLE
Вернуть сообщение в очередь

### DIFF
--- a/Client.pm
+++ b/Client.pm
@@ -226,6 +226,8 @@ sub sm_get_messages {
 		
 		if($callback->($self, $rmq->envelope_get_message_body($envelope))) {
 			$rmq->basic_ack($conn, $channel, $rmq->envelope_get_delivery_tag($envelope), 0);
+		} else {
+			$rmq->basic_nack($conn, $channel, $rmq->envelope_get_delivery_tag($envelope), 0, 1);
 		}
 		
 		$rmq->destroy_envelope($envelope);


### PR DESCRIPTION
Сейчас, если вернуть не 1 из $callback, сообщение "зависнет" до того момента, пока клиент не порвет соединение.
Было бы правильно возвращать сообщение в очередь.